### PR TITLE
Fix download card links

### DIFF
--- a/content/docs/getting-started/download-codex.mdx
+++ b/content/docs/getting-started/download-codex.mdx
@@ -35,19 +35,19 @@ Visit [codexeditor.app](https://codexeditor.app/) to access the download page wi
 
 <Cards>
   <Card 
-    href="#macos-installation" 
+    href="https://codexeditor.app/downloads" 
     title="macOS"
   >
     Download for Apple Silicon or Intel Macs
   </Card>
   <Card 
-    href="#windows-installation" 
+    href="https://codexeditor.app/downloads" 
     title="Windows"
   >
     Download x64 installer for Windows 10 or later
   </Card>
   <Card 
-    href="#linux-installation" 
+    href="https://codexeditor.app/downloads" 
     title="Linux"
   >
     Download for x64, arm64, or armhf architectures


### PR DESCRIPTION
Point the getting started download cards at the Codex downloads page.