### PR TITLE
Document antivirus blockage troubleshooting

### DIFF
--- a/components/troubleshooting-flow.tsx
+++ b/components/troubleshooting-flow.tsx
@@ -62,10 +62,11 @@ const troubleshootingPaths: TroubleshootingPath[] = [
       'Restart the application or reload the editor window.',
       'Verify you downloaded the correct installer for your OS and architecture.',
       'Re-download the installer if the file may be incomplete.',
-      'Check security prompts, antivirus, or system permission settings.',
+      'Check security prompts, antivirus exceptions, or system permission settings.',
       'On Linux, verify the executable has the correct permissions.',
     ],
     docs: [
+      { title: 'Antivirus or Anti-Malware Blocking Codex', href: '/docs/antivirus-blockages' },
       { title: 'Download Codex', href: '/docs/getting-started/download-codex' },
       { title: 'Initial Setup', href: '/docs/getting-started/initial-setup' },
     ],

--- a/content/docs/antivirus-blockages.mdx
+++ b/content/docs/antivirus-blockages.mdx
@@ -1,0 +1,57 @@
+---
+title: Antivirus or Anti-Malware Blocking Codex
+description: How to allow Codex when antivirus or anti-malware software blocks the app or its sync service
+---
+
+# Antivirus or Anti-Malware Blocking Codex
+
+Some antivirus, anti-malware, firewall, or endpoint protection tools may flag or block Codex. This is usually controlled by the third-party security app or by your organization's device policy, so the Codex team cannot remove the block from our side.
+
+The recommended fix is to allow Codex in the security tool that is blocking it.
+
+## What to Allow
+
+Add Codex to your antivirus or anti-malware exception list. Different tools use different names for this setting, such as:
+
+- **Exceptions**
+- **Exclusions**
+- **Allow list**
+- **Trusted sites**
+- **Do not block**
+
+If the tool asks for a website, server, or URL to allow, add:
+
+```text
+https://git.genesisrnd.com/
+```
+
+If the tool only accepts a domain instead of a full URL, use:
+
+```text
+git.genesisrnd.com
+```
+
+If the tool supports app-based exceptions, also allow the Codex application itself.
+
+## If You Have an IT Team
+
+If your computer is managed by an organization, school, or ministry IT team, ask them to add the Codex service URL to the antivirus, anti-malware, firewall, or endpoint protection exception list:
+
+```text
+https://git.genesisrnd.com/
+```
+
+They should be able to apply this through the security tool's **Exceptions**, **Allow list**, **Trusted sites**, or **Do not block** settings.
+
+## What Not to Do
+
+Do not permanently disable your antivirus or anti-malware protection. If you temporarily pause protection to confirm that it is the source of the problem, turn it back on and add an exception instead.
+
+## Still Blocked?
+
+Because this block is controlled by a third-party security product, the Codex team may not be able to resolve it directly. If Codex is still blocked after adding the exception:
+
+1. Note the name of the antivirus, anti-malware, firewall, or endpoint protection tool.
+2. Copy the exact warning or block message.
+3. Contact your IT person or security software support team and share the Codex service URL above.
+4. If you still need Codex support, complete the [Troubleshooting guide](/docs/troubleshooting) support form and include the security tool name and warning text.

--- a/content/docs/getting-started/initial-setup.mdx
+++ b/content/docs/getting-started/initial-setup.mdx
@@ -113,10 +113,11 @@ Codex requires internet access for AI features and project sync. Open a browser 
 
 **Step 5 — Check antivirus or firewall (Windows)**
 
-Antivirus software can block Codex from starting. Temporarily disable your antivirus and try again. If Codex opens, add it to your antivirus exceptions list.
+Antivirus software can block Codex from starting or connecting to its sync service. If this happens, follow the [antivirus and anti-malware troubleshooting guide](/docs/antivirus-blockages) to add Codex and the Codex service URL to your security tool's exceptions or allow list.
 
 Codex requires access to these domains:
 
+- `git.genesisrnd.com`
 - `api.frontierrnd.com`
 - `gitlab.com` and `git.door43.org`
 - `github.com` and `api.github.com`

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -2,6 +2,7 @@
   "title": "Codex Editor Documentation",
   "pages": [
     "troubleshooting",
+    "antivirus-blockages",
     "getting-started",
     "project-management",
     "translation",

--- a/content/docs/troubleshooting.mdx
+++ b/content/docs/troubleshooting.mdx
@@ -14,6 +14,9 @@ If something is not working in Codex Editor, start here before posting in Discor
 If you already know the area you need, jump straight to the deeper guide:
 
 <Cards>
+  <Card title="Antivirus or Anti-Malware Blocking Codex" href="/docs/antivirus-blockages">
+    Allow Codex and its sync service when security software blocks the app or network access.
+  </Card>
   <Card title="Install and Setup" href="/docs/getting-started/initial-setup">
     Fix install, sign-in, permissions, and first-run setup problems.
   </Card>


### PR DESCRIPTION
## Summary
- Add a troubleshooting page for antivirus, anti-malware, firewall, and endpoint protection tools blocking Codex.
- Link the new guide from the troubleshooting hub, initial setup docs, and guided troubleshooting flow.
- Include the Codex service URL users or IT teams should add to exceptions: `https://git.genesisrnd.com/`.

## Test plan
- [x] `git diff --check origin/main...HEAD`
- [x] ~~`pnpm postinstall` / `pnpm build` not run locally because `pnpm`, `npm`, and Corepack are unavailable in this environment.~~ pnpm install and run dev successful, no broken components detected. 


Made with [Cursor](https://cursor.com)