### PR TITLE
chore(security): audit fix, security headers, pinned toolchain, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,16 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.30.3
+        # Version comes from the "packageManager" field in package.json
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -83,7 +82,7 @@ jobs:
           PY
 
       - name: Check external links (lychee)
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: >-
             --no-progress
@@ -103,7 +102,7 @@ jobs:
 
       - name: Upload link check report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lychee-link-report
           path: lychee-report.md
@@ -120,3 +119,28 @@ jobs:
           echo "✅ External link checking completed (see lychee-link-report artifact for details)"
           echo ""
           echo "Your documentation site is healthy! 🚀"
+
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Fails on high/critical advisories. If upstream advisories with no
+      # released fix start blocking unrelated PRs, relax with
+      # `continue-on-error: true` rather than deleting the job.
+      - name: Dependency audit
+        run: pnpm audit --audit-level high

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,26 @@ const config = {
       },
     ],
   },
+  // Baseline security headers. These also reach users browsing via the
+  // codexeditor.app/docs proxy (it preserves upstream response headers);
+  // 'self' is origin-relative, so framing rules behave correctly on both
+  // hosts. Full CSP (script-src etc.) is deliberately not attempted here —
+  // Next app-router inline scripts make that a separate project.
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+          { key: 'Strict-Transport-Security', value: 'max-age=31536000' },
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'self'" },
+        ],
+      },
+    ];
+  },
 };
 
 export default withMDX(config);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "codex-documentation",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "pnpm@10.30.3",
   "scripts": {
     "build": "next build",
     "dev": "next dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,8 +1462,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4589,7 +4589,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6237,7 +6237,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

Security pass mirroring the one completed on codex-website (genesis-ai-dev/codex-website#19–#21), scaled to this repo's much smaller surface.

## Changes

- **Audit**: the single `pnpm audit` finding (brace-expansion <5.0.6 ReDoS-style DoS, GHSA-jxxr-4gwj-5jf2, dev tooling) fixed via transitive update → **0 known vulnerabilities**.
- **Security response headers** via `next.config.mjs headers()`: nosniff, strict referrer policy, Permissions-Policy (camera/mic/geo off), HSTS 1y, `X-Frame-Options: SAMEORIGIN` + `frame-ancestors 'self'`. Worth noting: these headers also reach readers browsing through the **codexeditor.app/docs proxy**, which preserves upstream response headers; `'self'` is origin-relative so framing rules behave correctly on both hosts. Full CSP (script-src etc.) deliberately deferred — Next app-router inline scripts make that its own project.
- **Toolchain pinning**: `packageManager: pnpm@10.30.3` in package.json; CI reads it instead of a hardcoded version; Node 20 → 22.
- **CI hardening**: all five actions SHA-pinned with version comments (checkout, pnpm/action-setup, setup-node, **lychee-action**, **upload-artifact** — each SHA verified against the upstream tag); new `audit` job failing on high/critical advisories.
- **Dependabot**: weekly npm (minor/patch grouped into one PR) + GitHub Actions updates, so the pins and the clean audit don't decay.

## Verification

- `pnpm audit` → No known vulnerabilities found
- `pnpm exec tsc --noEmit` → clean
- `pnpm build` → production build succeeds
- ci.yml parses (PyYAML), jobs: build-and-test, audit

Heads-up: expect a small burst of Dependabot PRs right after merge (initial scan), pre-screened by the CI gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)