### PR TITLE
ci: bump Node 22 -> 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem
CI pinned Node 22 on the belief that Fumadocs didn't support anything newer. That's no longer the case:

- Fumadocs packages (`fumadocs-core`/`-ui`/`-mdx`) declare **no** `engines` constraint at all
- The Fumadocs monorepo itself requires **Node >= 24.14** and its CI tests on Node 24
- The only floor in our stack is Next.js 16, which needs Node >= 20.9

## Change
Bump `node-version: '22'` -> `'24'` in both CI jobs (build and audit).

## Why
Node 24 is the current LTS and matches what upstream Fumadocs develops against. This also unblocks the `@types/node` 22 -> 24 Dependabot PR, so our type definitions match the runtime CI actually uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)