### PR TITLE
chore: drop deprecated baseUrl from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "ESNext",
     "lib": [
       "dom",


### PR DESCRIPTION
TypeScript 6 deprecates `baseUrl` (TS5101, removed in TS 7) — it's what fails CI on the `typescript` 6.x Dependabot bump. The `paths` entries here are already relative (`./*`), which since TS 4.1 resolves against the tsconfig location without `baseUrl`, and a grep shows no bare baseUrl-style imports — everything uses the `@/` alias. So removing the option is behavior-neutral on TS 5.9 and unblocks TS 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)