### PR TITLE
docs: update release notes and feature pages for Codex Translation Editor 0.30.0

### DIFF
--- a/content/docs/project-management/importing-files.mdx
+++ b/content/docs/project-management/importing-files.mdx
@@ -36,7 +36,7 @@ Importers are grouped by general-purpose and specialized workflows. The exact li
 | --- | --- | --- |
 | **Audio** | `.mp3`, `.wav`, `.m4a`, `.aac`, `.ogg`, `.webm`, `.flac` | Creates audio-linked cells for transcription or translation workflows. |
 | **Subtitles** | `.vtt`, `.srt` | Preserves cue timing for subtitle translation and export. |
-| **Word Documents** | `.docx` | Supports round-trip export back to DOCX. |
+| **Word Documents** | `.docx` | Supports round-trip export back to DOCX. Long passages can be split into properly sized cells during import. |
 | **Markdown** | `.md`, `.markdown`, `.mdown`, `.mkd` | Supports round-trip Markdown workflows and image handling. |
 | **TMS Files** | `.tmx`, `.xliff`, `.xlf` | For localization and translation-memory workflows. |
 | **InDesign** | `.idml` | Supports layout-oriented round-trip workflows. |

--- a/content/docs/releases/latest.mdx
+++ b/content/docs/releases/latest.mdx
@@ -11,35 +11,45 @@ This page summarizes user-facing changes that matter when following the document
 
 | Component | Latest stable release reflected here |
 | --- | --- |
-| **Codex Translation Editor extension** | `0.29.0` |
+| **Codex Translation Editor extension** | `0.30.0` |
 | **Codex desktop app** | `1.108.13184` |
 
 <Callout type="info">
 If your installed version is older, update Codex before troubleshooting behavior that differs from these docs.
 </Callout>
 
-## Codex Translation Editor 0.29.0
+## Codex Translation Editor 0.30.0
 
-Published June 22, 2026.
+Published July 13, 2026.
 
-### Media and Audio
+### New Features
 
-- The play-video button is available even when the cell does not have recorded audio yet.
-- URL and video file deletion now asks for confirmation before removing the item.
-- Overlapping subtitle timestamp handling was fixed for a media project edge case.
-- Character audio export functionality and audio export options were expanded.
+- **Audio track selector** in the video player: when a streamed video offers more than one language track, pick which audio track plays. See [Video and Audio Translation](/docs/translation/video-audio-translation).
+- **Advanced speech recognition (ASR)**: transcription now includes language auto-detection, a new **Re-transcribe** option, and updated settings.
 
-### Export and Project Structure
+### Improvements
 
-- Export cancellation and media download strategy behavior were improved.
-- Milestone hoisting in verse-range reordering was fixed, improving structured scripture workflows.
+- **Faster project opening**: smarter media handling skips unnecessary downloads and saves bandwidth, especially for **Stream Only** projects.
+- **Better Word (.docx) import**: an option splits long passages into properly sized cells instead of one large block.
+- **HTML formatting in AI edits**: when HTML Enforcement is turned on, AI suggestions from the sparkle button keep valid formatting, and a new **Resolve All** action fixes flagged formatting mismatches in bulk.
+- **Tidier exports**: exporting files that have no audio no longer creates empty folders, and exported file names now include verse ranges.
 
-### Interface and Updates
+### Fixes
 
-- The **Restart Now** button no longer overflows its container.
-- The extension package now targets the `0.29.0` release and updates the required Frontier Authentication version.
+- The **Publish to Cloud** button no longer covers text in narrow columns.
+- The audio status shown in the cell list is accurate again.
+- **Consolidate by Character** audio export now works in **Stream & Save** and **Stream Only** modes.
+- Deleting a video now stops it from continuing to load in streaming modes.
+- In the Export wizard, clicking a cell that has no audio now opens the correct chapter.
+- The **Unmerge** option for merged content was restored, and merging in the editor now asks for confirmation. See [Merging and Editing Source Cells](/docs/translation/merging-editing-source-cells).
+- Fixed several project-content issues: duplicate or repeated cells, mismatched verse ranges between source and target, source/target timestamp mismatches, deleted lines appearing in USFM export, and lingering Greek/Hebrew corpus marker titles after an overwrite.
+- Book names containing a period no longer lose the text after it when syncing.
 
-Full changelog: [codex-editor 0.29.0](https://github.com/genesis-ai-dev/codex-editor/releases/tag/0.29.0).
+### Versions and Requirements
+
+- The extension package now targets the `0.30.0` release and raises the required Frontier Authentication version to `0.9.0`. Pinned team projects receive compatible versions automatically.
+
+Full changelog: [codex-editor 0.30.0](https://github.com/genesis-ai-dev/codex-editor/releases/tag/0.30.0).
 
 ## Codex Desktop App 1.108.13184
 
@@ -53,6 +63,8 @@ Full changelog and downloads: [codex 1.108.13184](https://github.com/genesis-ai-
 ## Recent Features To Know
 
 - Media-heavy projects can choose **Auto Download Media**, **Stream & Save**, or **Stream Only**.
+- The video player can switch between audio language tracks when the video provides them.
+- Speech recognition supports language auto-detection and re-transcribing existing recordings.
 - Audio export includes character-consolidated workflows and expanded audio options.
 - Project swap and remote updates can require contributors to apply project-card updates before continuing.
 - Offline and server-unreachable states allow local projects to open even when cloud services are unavailable.

--- a/content/docs/translation/exporting-project.mdx
+++ b/content/docs/translation/exporting-project.mdx
@@ -79,8 +79,10 @@ Audio export is available for projects with audio attachments or media workflows
 - Include per-cell audio files.
 - Include timestamps.
 - Export audio alongside selected text formats.
-- **Consolidate by Character** for dialogue or dubbing workflows.
+- **Consolidate by Character** for dialogue or dubbing workflows. This works in every media strategy, including **Stream & Save** and **Stream Only**.
 - Preview character-consolidated output before export.
+
+Exported audio file names include verse ranges, and files with no audio no longer produce empty folders in the output.
 
 For video and dubbing workflows, see [Video and Audio Translation](/docs/translation/video-audio-translation).
 

--- a/content/docs/translation/merging-editing-source-cells.mdx
+++ b/content/docs/translation/merging-editing-source-cells.mdx
@@ -38,20 +38,21 @@ The controls are hidden by default to prevent accidental source changes.
 1. Enable source editing mode.
 2. Find the second cell in the pair you want to merge.
 3. Use the merge-with-previous action on that cell.
-4. Confirm the merge when prompted.
+4. Confirm the merge when prompted. Merging always asks for confirmation before changing the structure.
 5. Review the combined source text.
 6. Save the change.
 
 When source cells merge, the corresponding target structure is kept in sync so translators can work against the updated segmentation.
 
-## Revert or Clean Up a Merge
+## Unmerge a Merged Cell
 
-If a merge was not right:
+If a merge was not right, you can undo it:
 
-1. Use the revert action when it is available.
-2. Review both source and target content afterward.
-3. Clean up any extra text that remains.
-4. Sync the project if others are working from the same files.
+1. In source editing mode, find the merged cell. Merged content appears greyed out.
+2. Click **Unmerge** on that cell.
+3. Review both source and target content afterward.
+4. Clean up any extra text that remains.
+5. Sync the project if others are working from the same files.
 
 ## Edit Source Text
 

--- a/content/docs/translation/translation-tools.mdx
+++ b/content/docs/translation/translation-tools.mdx
@@ -31,6 +31,8 @@ Codex has two AI autocomplete flows:
 
 AI suggestions depend on the project system message, source and target languages, surrounding context, and edits already made in the project.
 
+When **HTML Enforcement** is turned on for the project, AI suggestions keep valid formatting, and cells whose formatting no longer matches the expected structure are flagged. Use the **Resolve All** action in the chapter menu to fix flagged cells in bulk instead of editing them one at a time.
+
 <Callout type="warning">
 AI suggestions are drafts. Review, edit, and validate them before treating them as final translation.
 </Callout>

--- a/content/docs/translation/video-audio-translation.mdx
+++ b/content/docs/translation/video-audio-translation.mdx
@@ -28,9 +28,19 @@ Cell audio tools can include:
 - Play audio.
 - Record target audio.
 - Rerecord or remove audio.
-- Transcribe speech to text.
+- Transcribe speech to text, with automatic language detection.
+- **Re-transcribe** an existing recording after changing transcription settings.
+- Copy timestamps from the matching source cell when source and target timing drift apart.
 - Validate audio.
 - Use a countdown before recording starts.
+
+<Callout type="info">
+If Codex does not detect a microphone, the record button is disabled and a warning explains why. Check your input device and system permissions, then reopen the cell.
+</Callout>
+
+## Video Audio Tracks
+
+When a streamed video provides more than one audio language track, the video player shows an audio track selector. Use it to pick which language plays while you translate. The selector only appears when the video actually offers multiple tracks.
 
 ## Media Storage
 


### PR DESCRIPTION
## Summary

The docs were last aligned at the June 23 refactor (extension 0.29.0). Codex Translation Editor **0.30.0** shipped July 13 and is now the Latest release on GitHub, so this PR brings the releases page up to date and folds the new features into the pages where users would look for them.

### Releases page (`releases/latest.mdx`)
- Version table: extension `0.29.0` → `0.30.0` (desktop app row unchanged, `1.108.13184` is still current).
- New 0.30.0 section based on the customer release announcement, organized as New Features / Improvements / Fixes / Versions and Requirements. Same-class per-project fixes (duplicate cells, repeated content, mismatched ranges) are consolidated into single bullets.
- Documents the required Frontier Authentication version raised to `0.9.0` (enforced at runtime by the extension).

### Feature fold-ins
- **video-audio-translation**: new "Video Audio Tracks" section for the audio track selector; ASR language auto-detection + Re-transcribe; no-microphone warning callout; copy-timestamps-from-source cell tool.
- **translation-tools**: HTML Enforcement behavior for AI suggestions and the Resolve All bulk action.
- **merging-editing-source-cells**: concrete "Unmerge a Merged Cell" walkthrough (replaces the vague "revert action" text); merge confirmation noted.
- **exporting-project**: Consolidate by Character in all media strategies; verse ranges in file names; no empty folders.
- **importing-files**: DOCX long-passage splitting note. (InDesign/Biblica importers were already documented here by the June refactor; they're left off the release notes to match the customer announcement.)

## Verification

- `pnpm build` passes; all 38 pages generate.
- Version facts cross-checked against `codex-editor` at `main` (0.30.0): required Frontier Authentication version from `src/projectManager/utils/versionChecks.ts`, feature behavior from the 0.30.0 release notes and the implementing PRs (#1077 audio tracks, #1088 Resolve All, #1024 unmerge, #1087 timestamp copy, #894 DOCX splitting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)