### PR TITLE
docs: fix version-help anchor, stale example versions, and architecture chart

### DIFF
--- a/components/codex-architecture-chart.tsx
+++ b/components/codex-architecture-chart.tsx
@@ -88,36 +88,44 @@ export function CodexArchitectureChart() {
         label="Foundation"
         sublabel="Desktop application for Windows, macOS, and Linux"
       >
-        <Link
-          href="/docs/getting-started/download-codex"
-          className="block rounded-xl border border-fd-primary/20 bg-fd-primary/5 px-4 py-3 text-center transition-colors hover:bg-fd-primary/10 hover:border-fd-primary/40"
-        >
-          <p className="text-sm font-semibold text-fd-foreground">
-            Codex Application
-          </p>
-          <p className="mt-0.5 text-xs text-fd-muted-foreground">
-            Custom VS Code distribution (via VSCodium) with Open VSX marketplace
-          </p>
-          <p className="mt-2 inline-flex items-center gap-1 rounded-md bg-fd-primary/10 px-2.5 py-1 text-xs font-medium text-fd-primary">
-            Download for your platform →
-          </p>
-        </Link>
+        <div className="space-y-3">
+          <Link
+            href="/docs/getting-started/download-codex"
+            className="block rounded-xl border border-fd-primary/20 bg-fd-primary/5 px-4 py-3 text-center transition-colors hover:bg-fd-primary/10 hover:border-fd-primary/40"
+          >
+            <p className="text-sm font-semibold text-fd-foreground">
+              Codex Application
+            </p>
+            <p className="mt-0.5 text-xs text-fd-muted-foreground">
+              Custom VS Code distribution (via VSCodium) with Open VSX marketplace
+            </p>
+            <p className="mt-2 inline-flex items-center gap-1 rounded-md bg-fd-primary/10 px-2.5 py-1 text-xs font-medium text-fd-primary">
+              Download for your platform →
+            </p>
+          </Link>
+          <div className="grid grid-cols-2 gap-3">
+            <ExtensionCard
+              name="CodexSideloader"
+              desc="Built into the app — installs the required core extensions from Open VSX when they are missing"
+              muted
+            />
+            <ExtensionCard
+              name="CodexConductor"
+              desc="Built into the app — manages extension version pins and project-specific profiles"
+              muted
+            />
+          </div>
+        </div>
       </LayerSection>
 
       <LayerConnector />
 
       <LayerSection
         label="Extension Layer"
-        sublabel="Modular components installed from Open VSX"
+        sublabel="Core extensions installed from Open VSX"
         accent
       >
         <div className="grid grid-cols-2 gap-3">
-          <ExtensionCard
-            name="Extension Sideloader"
-            desc="Bundled in the binary — activates on first launch, fetches the extensions below, then sits idle"
-            wide
-            muted
-          />
           <ExtensionCard
             name="Codex Translation Editor"
             desc="Custom .codex notebook editor, AI-powered translation tools, language server, and webview panels"

--- a/components/troubleshooting-flow.tsx
+++ b/components/troubleshooting-flow.tsx
@@ -247,8 +247,8 @@ const VERSION_HELP_HREF = '/docs/project-management/update-extensions#verifying-
 const requiredFields: { key: EvidenceFieldKey; label: string; placeholder: string; multiline: boolean; helpHref?: string; helpLabel?: string }[] = [
   { key: 'projectName', label: 'Project name', placeholder: 'e.g. My Translation Project', multiline: false },
   { key: 'username', label: 'Username', placeholder: 'Your Codex account username', multiline: false },
-  { key: 'appVersion', label: 'Codex app version', placeholder: 'e.g. 1.108.11148', multiline: false, helpHref: `${VERSION_HELP_HREF}`, helpLabel: 'How to find this (Help → About)' },
-  { key: 'extensionVersion', label: 'Extension version', placeholder: 'e.g. 1.8.0', multiline: false, helpHref: `${VERSION_HELP_HREF}`, helpLabel: 'How to find this (Extensions panel)' },
+  { key: 'appVersion', label: 'Codex app version', placeholder: 'e.g. 1.108.13184', multiline: false, helpHref: `${VERSION_HELP_HREF}`, helpLabel: 'How to find this (Help → About)' },
+  { key: 'extensionVersion', label: 'Extension version', placeholder: 'e.g. 0.30.0', multiline: false, helpHref: `${VERSION_HELP_HREF}`, helpLabel: 'How to find this (Extensions panel)' },
   { key: 'operatingSystem', label: 'Operating system', placeholder: 'e.g. macOS 15, Ubuntu 24.04, Windows 11', multiline: false },
   { key: 'task', label: 'Describe the issue', placeholder: 'What is going wrong?', multiline: false },
   { key: 'reproductionSteps', label: 'Exact steps to reproduce', placeholder: 'List the steps someone else could follow', multiline: true },

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -41,6 +41,8 @@ Codex is not only a website and not only an extension. It has two user-visible l
   </Step>
 </Steps>
 
+<CodexArchitectureChart />
+
 <Callout type="info">
 Codex can work offline after the app and required extensions are installed, but first launch, project downloads, AI suggestions, sync, and new extension version pins require network access.
 </Callout>

--- a/content/docs/project-management/update-extensions.mdx
+++ b/content/docs/project-management/update-extensions.mdx
@@ -55,6 +55,13 @@ Manual extension updates are mainly for unpinned projects or support-directed tr
 4. Update or install a specific version only if the project is not pinned or support has instructed you to do so.
 5. Reload Codex.
 
+## Verifying Your Versions
+
+Support requests and bug reports usually need both version numbers:
+
+- **App version**: **Help > About Codex** on Windows/Linux, or **Codex > About Codex** on macOS.
+- **Extension version**: open the Extensions panel and find **Codex Translation Editor**. The version number appears next to the extension name.
+
 ## Troubleshooting Update Issues
 
 ### Codex is stuck applying extension pins


### PR DESCRIPTION
## Summary

Three site-quality fixes found during the docs audit that produced #60 (independent of it — branched from main):

1. **Broken anchor**: the troubleshooting wizard's two "How to find this" helper links point at `update-extensions#verifying-your-versions`, which never existed. Added a **Verifying Your Versions** section to `update-extensions.mdx` so the links land somewhere useful.
2. **Misleading example versions**: the wizard's placeholders showed an outdated app build (`1.108.11148`) and an extension version that has never existed (`1.8.0` — the Translation Editor is on 0.x). Now `1.108.13184` / `0.30.0`.
3. **Dead + inaccurate architecture chart**: `CodexArchitectureChart` was registered but used by zero pages, and its content was the pre-refactor story — sideloader named inconsistently with `index.mdx`, placed in the "installed from Open VSX" layer, and no CodexConductor. Fixed the layering (Sideloader + Conductor are compiled into the app binary via the codex repo's `feat-codex-sideloader` / `feat-codex-conductor` patches; only the Translation Editor, Frontier Authentication, and Shared State Store come from Open VSX) and embedded the chart on the docs landing page under "How Codex Is Organized".

## Verification

- `pnpm build` passes; all pages generate.
- `#verifying-your-versions` confirmed present in the built `update-extensions` HTML.
- Chart layering verified against the `codex` build repo's patch set rather than prior docs copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)