### PR TITLE
Add AI-powered docs assistant chat widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 .env*.local
 .vercel
 next-env.d.ts
+# generated docs corpus for the Ask AI assistant
+/lib/docs-corpus.generated.json

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ pnpm watch
 
 The docs site includes an "Ask AI" chat widget (bottom-right of every docs page) that answers verbatim questions from the documentation. It sends the full docs corpus to Claude Haiku with prompt caching, so no search index or vector database is involved.
 
-- Set `ANTHROPIC_API_KEY` in the deployment environment to enable it. Without the key, the widget shows a "not configured" message and the rest of the site works normally.
-- Optionally set `CHATBOT_MODEL` to override the model (defaults to `claude-haiku-4-5`).
-- The API route is `app/api/chat/route.ts`; the widget is `components/ask-ai.tsx`; the corpus builder is `lib/docs-corpus.ts`. New or edited MDX pages are picked up automatically on the next deploy.
+- The model is chosen with `CHATBOT_MODEL` (defaults to `claude-haiku-4-5`). The provider is inferred from the model name: `claude-*` uses Anthropic (requires `ANTHROPIC_API_KEY`), anything else uses OpenAI (requires `OPENAI_API_KEY`) — e.g. `CHATBOT_MODEL=gpt-5.6-luna`. Swap models by changing the env var; no code changes needed.
+- Without the matching API key, the widget shows a "not configured" message and the rest of the site works normally.
+- The API route is `app/api/chat/route.ts`; the provider layer is `lib/chat-provider.ts`; the widget is `components/ask-ai.tsx`; the corpus builder is `lib/docs-corpus.ts`. New or edited MDX pages are picked up automatically on the next deploy.
 
 ## Content Map
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ pnpm build
 pnpm watch
 ```
 
+## Docs Assistant (Ask AI)
+
+The docs site includes an "Ask AI" chat widget (bottom-right of every docs page) that answers verbatim questions from the documentation. It sends the full docs corpus to Claude Haiku with prompt caching, so no search index or vector database is involved.
+
+- Set `ANTHROPIC_API_KEY` in the deployment environment to enable it. Without the key, the widget shows a "not configured" message and the rest of the site works normally.
+- Optionally set `CHATBOT_MODEL` to override the model (defaults to `claude-haiku-4-5`).
+- The API route is `app/api/chat/route.ts`; the widget is `components/ask-ai.tsx`; the corpus builder is `lib/docs-corpus.ts`. New or edited MDX pages are picked up automatically on the next deploy.
+
 ## Content Map
 
 - `content/docs/` contains MDX documentation pages.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,10 +1,9 @@
-import Anthropic from '@anthropic-ai/sdk';
 import { getDocsCorpus } from '@/lib/docs-corpus';
+import { chatConfigured, streamChat, type ChatMessage } from '@/lib/chat-provider';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
-const MODEL = process.env.CHATBOT_MODEL ?? 'claude-haiku-4-5';
 const MAX_MESSAGES = 20;
 const MAX_MESSAGE_LENGTH = 4000;
 
@@ -35,7 +34,7 @@ Rules:
 - If the question is unrelated to Codex Editor or its documentation, politely decline and redirect to the docs.`;
 
 export async function POST(req: Request): Promise<Response> {
-  if (!process.env.ANTHROPIC_API_KEY) {
+  if (!chatConfigured()) {
     return Response.json(
       { error: 'The docs assistant is not configured on this deployment.' },
       { status: 503 },
@@ -50,7 +49,7 @@ export async function POST(req: Request): Promise<Response> {
     );
   }
 
-  let messages: { role: 'user' | 'assistant'; content: string }[];
+  let messages: ChatMessage[];
   try {
     const body = await req.json();
     messages = body.messages;
@@ -72,42 +71,9 @@ export async function POST(req: Request): Promise<Response> {
     return Response.json({ error: 'Invalid request body.' }, { status: 400 });
   }
 
-  const client = new Anthropic();
+  const system = `${INSTRUCTIONS}\n\n<documentation>\n${getDocsCorpus()}\n</documentation>`;
 
-  const stream = client.messages.stream({
-    model: MODEL,
-    max_tokens: 1024,
-    system: [
-      {
-        type: 'text',
-        text: `${INSTRUCTIONS}\n\n<documentation>\n${getDocsCorpus()}\n</documentation>`,
-        // The instructions + docs corpus are identical on every request, so
-        // repeat questions read them from cache at ~10% of input price.
-        cache_control: { type: 'ephemeral' },
-      },
-    ],
-    messages,
-  });
-
-  const encoder = new TextEncoder();
-  const readable = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stream.on('text', (delta) => controller.enqueue(encoder.encode(delta)));
-      stream.on('end', () => controller.close());
-      stream.on('error', (err) => {
-        console.error('chat stream error:', err);
-        controller.enqueue(
-          encoder.encode('\n\nSorry, something went wrong. Please try again.'),
-        );
-        controller.close();
-      });
-    },
-    cancel() {
-      stream.abort();
-    },
-  });
-
-  return new Response(readable, {
+  return new Response(streamChat(system, messages), {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
       'Cache-Control': 'no-store',

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,116 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { getDocsCorpus } from '@/lib/docs-corpus';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const MODEL = process.env.CHATBOT_MODEL ?? 'claude-haiku-4-5';
+const MAX_MESSAGES = 20;
+const MAX_MESSAGE_LENGTH = 4000;
+
+// Best-effort per-instance rate limit; good enough to stop casual abuse of a
+// public docs endpoint without adding infrastructure.
+const RATE_LIMIT = 10;
+const RATE_WINDOW_MS = 60_000;
+const hits = new Map<string, number[]>();
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const recent = (hits.get(ip) ?? []).filter((t) => now - t < RATE_WINDOW_MS);
+  if (recent.length >= RATE_LIMIT) return true;
+  recent.push(now);
+  hits.set(ip, recent);
+  if (hits.size > 10_000) hits.clear();
+  return false;
+}
+
+const INSTRUCTIONS = `You are the documentation assistant for Codex Editor, embedded in the official docs site. Answer questions from translators, project coordinators, media teams, and support staff using ONLY the documentation provided below.
+
+Rules:
+- Answer from the documentation. If the docs don't cover something, say so plainly and suggest the closest relevant page — never invent features, menu labels, or behavior.
+- Use current Codex UI labels exactly as they appear in the docs.
+- When app behavior is involved, distinguish the Codex desktop app from the Codex Translation Editor extension.
+- Keep answers short and task-focused. Link to the relevant page using its url from the page metadata, as a markdown link like [Page Title](/docs/...).
+- Use "cell" or "segment" for general workflows; use "verse" only for scripture-specific guidance.
+- If the question is unrelated to Codex Editor or its documentation, politely decline and redirect to the docs.`;
+
+export async function POST(req: Request): Promise<Response> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return Response.json(
+      { error: 'The docs assistant is not configured on this deployment.' },
+      { status: 503 },
+    );
+  }
+
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+  if (rateLimited(ip)) {
+    return Response.json(
+      { error: 'Too many requests — please wait a minute and try again.' },
+      { status: 429 },
+    );
+  }
+
+  let messages: { role: 'user' | 'assistant'; content: string }[];
+  try {
+    const body = await req.json();
+    messages = body.messages;
+    if (
+      !Array.isArray(messages) ||
+      messages.length === 0 ||
+      messages.length > MAX_MESSAGES ||
+      messages.some(
+        (m) =>
+          (m.role !== 'user' && m.role !== 'assistant') ||
+          typeof m.content !== 'string' ||
+          m.content.length === 0 ||
+          m.content.length > MAX_MESSAGE_LENGTH,
+      )
+    ) {
+      throw new Error('invalid');
+    }
+  } catch {
+    return Response.json({ error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  const client = new Anthropic();
+
+  const stream = client.messages.stream({
+    model: MODEL,
+    max_tokens: 1024,
+    system: [
+      {
+        type: 'text',
+        text: `${INSTRUCTIONS}\n\n<documentation>\n${getDocsCorpus()}\n</documentation>`,
+        // The instructions + docs corpus are identical on every request, so
+        // repeat questions read them from cache at ~10% of input price.
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages,
+  });
+
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream<Uint8Array>({
+    start(controller) {
+      stream.on('text', (delta) => controller.enqueue(encoder.encode(delta)));
+      stream.on('end', () => controller.close());
+      stream.on('error', (err) => {
+        console.error('chat stream error:', err);
+        controller.enqueue(
+          encoder.encode('\n\nSorry, something went wrong. Please try again.'),
+        );
+        controller.close();
+      });
+    },
+    cancel() {
+      stream.abort();
+    },
+  });
+
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -2,6 +2,7 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import type { ReactNode } from 'react';
 import { baseOptions } from '@/app/layout.config';
 import { source } from '@/lib/source';
+import { AskAI } from '@/components/ask-ai';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
@@ -28,6 +29,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       }}
     >
       {children}
+      <AskAI />
     </DocsLayout>
   );
 }

--- a/components/ask-ai.tsx
+++ b/components/ask-ai.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from 'react';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const SUGGESTIONS = [
+  'How do I create a new translation project?',
+  'How do I import an existing translation?',
+  'What is the difference between the desktop app and the extension?',
+];
+
+/**
+ * Minimal renderer for the markdown subset the assistant is prompted to use:
+ * paragraphs, bullet lists, links, bold, and inline code.
+ */
+function renderInline(text: string, keyPrefix: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const pattern = /\[([^\]]+)\]\(([^)\s]+)\)|`([^`]+)`|\*\*([^*]+)\*\*/g;
+  let last = 0;
+  let match: RegExpExecArray | null;
+  let i = 0;
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > last) nodes.push(text.slice(last, match.index));
+    const key = `${keyPrefix}-${i++}`;
+    if (match[1] !== undefined) {
+      const href = match[2];
+      nodes.push(
+        href.startsWith('/') ? (
+          <Link key={key} href={href} className="text-fd-primary underline underline-offset-2">
+            {match[1]}
+          </Link>
+        ) : (
+          <a
+            key={key}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-fd-primary underline underline-offset-2"
+          >
+            {match[1]}
+          </a>
+        ),
+      );
+    } else if (match[3] !== undefined) {
+      nodes.push(
+        <code key={key} className="rounded bg-fd-muted px-1 py-0.5 text-[0.85em]">
+          {match[3]}
+        </code>,
+      );
+    } else if (match[4] !== undefined) {
+      nodes.push(
+        <strong key={key} className="font-semibold">
+          {match[4]}
+        </strong>,
+      );
+    }
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+function AssistantMarkdown({ content }: { content: string }) {
+  const blocks: ReactNode[] = [];
+  const lines = content.split('\n');
+  let list: string[] = [];
+  let paragraph: string[] = [];
+  let key = 0;
+
+  const flushList = () => {
+    if (list.length === 0) return;
+    blocks.push(
+      <ul key={key++} className="my-1 list-disc space-y-1 pl-5">
+        {list.map((item, i) => (
+          <li key={i}>{renderInline(item, `li-${key}-${i}`)}</li>
+        ))}
+      </ul>,
+    );
+    list = [];
+  };
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    blocks.push(<p key={key++}>{renderInline(paragraph.join(' '), `p-${key}`)}</p>);
+    paragraph = [];
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const bullet = trimmed.match(/^[-*]\s+(.*)$/);
+    if (bullet) {
+      flushParagraph();
+      list.push(bullet[1]);
+    } else if (trimmed === '') {
+      flushList();
+      flushParagraph();
+    } else {
+      flushList();
+      paragraph.push(trimmed);
+    }
+  }
+  flushList();
+  flushParagraph();
+
+  return <div className="space-y-2">{blocks}</div>;
+}
+
+export function AskAI() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages]);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const ask = useCallback(
+    async (question: string) => {
+      const trimmed = question.trim();
+      if (trimmed === '' || loading) return;
+      const history = [...messages, { role: 'user' as const, content: trimmed }];
+      setMessages([...history, { role: 'assistant', content: '' }]);
+      setInput('');
+      setLoading(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const appendToAnswer = (text: string) => {
+        setMessages((prev) => {
+          const next = [...prev];
+          const last = next[next.length - 1];
+          next[next.length - 1] = { ...last, content: last.content + text };
+          return next;
+        });
+      };
+
+      try {
+        const res = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messages: history }),
+          signal: controller.signal,
+        });
+        if (!res.ok || !res.body) {
+          const detail = await res.json().catch(() => null);
+          appendToAnswer(
+            detail?.error ?? 'Sorry, something went wrong. Please try again.',
+          );
+          return;
+        }
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          appendToAnswer(decoder.decode(value, { stream: true }));
+        }
+      } catch (err) {
+        if (!(err instanceof DOMException && err.name === 'AbortError')) {
+          appendToAnswer('Sorry, something went wrong. Please try again.');
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [messages, loading],
+  );
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    void ask(input);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? 'Close docs assistant' : 'Ask AI about the docs'}
+        className="fixed bottom-5 right-5 z-40 flex items-center gap-2 rounded-full border border-fd-border bg-fd-background px-4 py-2.5 text-sm font-medium text-fd-foreground shadow-lg transition-colors hover:bg-fd-accent"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M12 3a6 6 0 0 0-6 6c0 2 1 3.5 2 4.5V16a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-2.5c1-1 2-2.5 2-4.5a6 6 0 0 0-6-6Z" />
+          <path d="M10 21h4" />
+        </svg>
+        Ask AI
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Docs assistant"
+          className="fixed bottom-20 right-5 z-40 flex h-[min(32rem,calc(100dvh-7rem))] w-[min(24rem,calc(100vw-2.5rem))] flex-col overflow-hidden rounded-xl border border-fd-border bg-fd-background shadow-2xl"
+        >
+          <div className="flex items-center justify-between border-b border-fd-border px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold">Docs assistant</p>
+              <p className="text-xs text-fd-muted-foreground">
+                AI answers from the Codex docs — may make mistakes.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              className="rounded p-1 text-fd-muted-foreground hover:text-fd-foreground"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-sm">
+            {messages.length === 0 ? (
+              <div className="space-y-2">
+                <p className="text-fd-muted-foreground">
+                  Ask a question in your own words, for example:
+                </p>
+                {SUGGESTIONS.map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => void ask(s)}
+                    className="block w-full rounded-lg border border-fd-border px-3 py-2 text-left text-fd-foreground transition-colors hover:bg-fd-accent"
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              messages.map((m, i) =>
+                m.role === 'user' ? (
+                  <div key={i} className="flex justify-end">
+                    <div className="max-w-[85%] rounded-lg bg-fd-primary/10 px-3 py-2">
+                      {m.content}
+                    </div>
+                  </div>
+                ) : (
+                  <div key={i} className="max-w-full">
+                    {m.content === '' && loading && i === messages.length - 1 ? (
+                      <p className="animate-pulse text-fd-muted-foreground">Thinking…</p>
+                    ) : (
+                      <AssistantMarkdown content={m.content} />
+                    )}
+                  </div>
+                ),
+              )
+            )}
+          </div>
+
+          <form onSubmit={onSubmit} className="flex gap-2 border-t border-fd-border p-3">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Ask about Codex Editor…"
+              maxLength={4000}
+              className="flex-1 rounded-lg border border-fd-border bg-fd-background px-3 py-2 text-sm outline-none placeholder:text-fd-muted-foreground focus:border-fd-primary"
+            />
+            <button
+              type="submit"
+              disabled={loading || input.trim() === ''}
+              className="rounded-lg bg-fd-primary px-3 py-2 text-sm font-medium text-fd-primary-foreground transition-opacity disabled:opacity-50"
+            >
+              Send
+            </button>
+          </form>
+        </div>
+      )}
+    </>
+  );
+}

--- a/lib/chat-provider.ts
+++ b/lib/chat-provider.ts
@@ -1,0 +1,121 @@
+import Anthropic from '@anthropic-ai/sdk';
+import OpenAI from 'openai';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Provider-agnostic chat layer. The active model is chosen with the
+ * CHATBOT_MODEL env var and the provider is inferred from its name:
+ * `claude-*` routes to Anthropic, anything else to OpenAI
+ * (e.g. `gpt-5.6-luna`). Swap models by changing the env var — no code
+ * changes needed.
+ */
+export const CHAT_MODEL = process.env.CHATBOT_MODEL ?? 'claude-haiku-4-5';
+
+type Provider = 'anthropic' | 'openai';
+
+function provider(): Provider {
+  return CHAT_MODEL.startsWith('claude') ? 'anthropic' : 'openai';
+}
+
+export function chatConfigured(): boolean {
+  return provider() === 'anthropic'
+    ? Boolean(process.env.ANTHROPIC_API_KEY)
+    : Boolean(process.env.OPENAI_API_KEY);
+}
+
+const MAX_OUTPUT_TOKENS = 1024;
+
+function anthropicStream(
+  system: string,
+  messages: ChatMessage[],
+): ReadableStream<Uint8Array> {
+  const client = new Anthropic();
+  const stream = client.messages.stream({
+    model: CHAT_MODEL,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: system,
+        // The system prompt (instructions + docs corpus) is identical on
+        // every request, so repeat questions read it from cache at ~10%
+        // of input price.
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages,
+  });
+
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      stream.on('text', (delta) => controller.enqueue(encoder.encode(delta)));
+      stream.on('end', () => controller.close());
+      stream.on('error', (err) => {
+        console.error('chat stream error (anthropic):', err);
+        controller.enqueue(
+          encoder.encode('\n\nSorry, something went wrong. Please try again.'),
+        );
+        controller.close();
+      });
+    },
+    cancel() {
+      stream.abort();
+    },
+  });
+}
+
+function openaiStream(
+  system: string,
+  messages: ChatMessage[],
+): ReadableStream<Uint8Array> {
+  const client = new OpenAI();
+  const encoder = new TextEncoder();
+  const abort = new AbortController();
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        // OpenAI caches long stable prompt prefixes automatically — the
+        // system message just needs to come first and stay byte-identical.
+        const stream = await client.chat.completions.create(
+          {
+            model: CHAT_MODEL,
+            stream: true,
+            max_completion_tokens: MAX_OUTPUT_TOKENS,
+            messages: [{ role: 'system', content: system }, ...messages],
+          },
+          { signal: abort.signal },
+        );
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta?.content;
+          if (delta) controller.enqueue(encoder.encode(delta));
+        }
+        controller.close();
+      } catch (err) {
+        if (abort.signal.aborted) return;
+        console.error('chat stream error (openai):', err);
+        controller.enqueue(
+          encoder.encode('\n\nSorry, something went wrong. Please try again.'),
+        );
+        controller.close();
+      }
+    },
+    cancel() {
+      abort.abort();
+    },
+  });
+}
+
+export function streamChat(
+  system: string,
+  messages: ChatMessage[],
+): ReadableStream<Uint8Array> {
+  return provider() === 'anthropic'
+    ? anthropicStream(system, messages)
+    : openaiStream(system, messages);
+}

--- a/lib/docs-corpus.ts
+++ b/lib/docs-corpus.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DOCS_DIR = path.join(process.cwd(), 'content', 'docs');
+
+interface DocPage {
+  url: string;
+  title: string;
+  description: string;
+  body: string;
+}
+
+function parseFrontmatter(raw: string): {
+  title: string;
+  description: string;
+  body: string;
+} {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return { title: '', description: '', body: raw };
+  const frontmatter = match[1];
+  const get = (key: string) => {
+    const line = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+    return line ? line[1].trim().replace(/^['"]|['"]$/g, '') : '';
+  };
+  return {
+    title: get('title'),
+    description: get('description'),
+    body: raw.slice(match[0].length),
+  };
+}
+
+function collectPages(dir: string, segments: string[] = []): DocPage[] {
+  const pages: DocPage[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      pages.push(...collectPages(path.join(dir, entry.name), [...segments, entry.name]));
+    } else if (entry.name.endsWith('.mdx')) {
+      const raw = fs.readFileSync(path.join(dir, entry.name), 'utf8');
+      const { title, description, body } = parseFrontmatter(raw);
+      const slug = entry.name.replace(/\.mdx$/, '');
+      const urlSegments = slug === 'index' ? segments : [...segments, slug];
+      pages.push({
+        url: `/docs${urlSegments.length > 0 ? `/${urlSegments.join('/')}` : ''}`,
+        title: title || slug,
+        description,
+        body,
+      });
+    }
+  }
+  return pages;
+}
+
+let cachedCorpus: string | null = null;
+
+/**
+ * The full documentation corpus as a single string, with each page prefixed
+ * by its title and site URL so the model can cite pages by link. Built once
+ * per server instance; the whole corpus is ~30k tokens, small enough to fit
+ * in a single cached prompt.
+ */
+export function getDocsCorpus(): string {
+  if (cachedCorpus !== null) return cachedCorpus;
+  const pages = collectPages(DOCS_DIR);
+  pages.sort((a, b) => a.url.localeCompare(b.url));
+  cachedCorpus = pages
+    .map(
+      (page) =>
+        `<page url="${page.url}" title="${page.title}"${
+          page.description ? ` description="${page.description}"` : ''
+        }>\n${page.body.trim()}\n</page>`,
+    )
+    .join('\n\n');
+  return cachedCorpus;
+}

--- a/lib/docs-corpus.ts
+++ b/lib/docs-corpus.ts
@@ -1,74 +1,13 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
-const DOCS_DIR = path.join(process.cwd(), 'content', 'docs');
-
-interface DocPage {
-  url: string;
-  title: string;
-  description: string;
-  body: string;
-}
-
-function parseFrontmatter(raw: string): {
-  title: string;
-  description: string;
-  body: string;
-} {
-  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
-  if (!match) return { title: '', description: '', body: raw };
-  const frontmatter = match[1];
-  const get = (key: string) => {
-    const line = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
-    return line ? line[1].trim().replace(/^['"]|['"]$/g, '') : '';
-  };
-  return {
-    title: get('title'),
-    description: get('description'),
-    body: raw.slice(match[0].length),
-  };
-}
-
-function collectPages(dir: string, segments: string[] = []): DocPage[] {
-  const pages: DocPage[] = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (entry.isDirectory()) {
-      pages.push(...collectPages(path.join(dir, entry.name), [...segments, entry.name]));
-    } else if (entry.name.endsWith('.mdx')) {
-      const raw = fs.readFileSync(path.join(dir, entry.name), 'utf8');
-      const { title, description, body } = parseFrontmatter(raw);
-      const slug = entry.name.replace(/\.mdx$/, '');
-      const urlSegments = slug === 'index' ? segments : [...segments, slug];
-      pages.push({
-        url: `/docs${urlSegments.length > 0 ? `/${urlSegments.join('/')}` : ''}`,
-        title: title || slug,
-        description,
-        body,
-      });
-    }
-  }
-  return pages;
-}
-
-let cachedCorpus: string | null = null;
+import corpus from './docs-corpus.generated.json';
 
 /**
  * The full documentation corpus as a single string, with each page prefixed
- * by its title and site URL so the model can cite pages by link. Built once
- * per server instance; the whole corpus is ~30k tokens, small enough to fit
- * in a single cached prompt.
+ * by its title and site URL so the model can cite pages by link. Generated
+ * at build time by scripts/generate-docs-corpus.mjs (run via postinstall
+ * and the build script) and bundled as a JSON module, so the chat route
+ * works on hosts without a runtime filesystem (e.g. Cloudflare Workers).
+ * The whole corpus is ~30k tokens — small enough for a single cached prompt.
  */
 export function getDocsCorpus(): string {
-  if (cachedCorpus !== null) return cachedCorpus;
-  const pages = collectPages(DOCS_DIR);
-  pages.sort((a, b) => a.url.localeCompare(b.url));
-  cachedCorpus = pages
-    .map(
-      (page) =>
-        `<page url="${page.url}" title="${page.title}"${
-          page.description ? ` description="${page.description}"` : ''
-        }>\n${page.body.trim()}\n</page>`,
-    )
-    .join('\n\n');
-  return cachedCorpus;
+  return corpus.text;
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "packageManager": "pnpm@10.30.3",
   "scripts": {
-    "build": "next build",
+    "build": "node scripts/generate-docs-corpus.mjs && next build",
     "dev": "next dev",
     "start": "next start",
-    "postinstall": "fumadocs-mdx",
+    "postinstall": "fumadocs-mdx && node scripts/generate-docs-corpus.mjs",
     "watch": "fumadocs-mdx watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fumadocs-mdx": "14.2.11",
     "fumadocs-ui": "16.7.9",
     "next": "16.2.9",
+    "openai": "^7.3.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "watch": "fumadocs-mdx watch"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.115.0",
     "fumadocs-core": "16.7.9",
     "fumadocs-mdx": "14.2.11",
     "fumadocs-ui": "16.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       next:
         specifier: 16.2.9
         version: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      openai:
+        specifier: ^7.3.0
+        version: 7.3.0(zod@4.4.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -2811,6 +2814,27 @@ packages:
 
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  openai@7.3.0:
+    resolution: {integrity: sha512-FLnIAkDEP3grs+BSDpqxEWVR37yG97/hs95lajF8SnHuA5nqtssh0uJVXbPhODNEoZqar+nEd+fIeGJgwoLUmg==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -6467,6 +6491,10 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  openai@7.3.0(zod@4.4.3):
+    optionalDependencies:
+      zod: 4.4.3
 
   optionator@0.9.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.115.0
+        version: 0.115.0(zod@4.4.3)
       fumadocs-core:
         specifier: 16.7.9
         version: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
@@ -83,6 +86,15 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@anthropic-ai/sdk@0.115.0':
+    resolution: {integrity: sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
@@ -137,6 +149,10 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -1055,6 +1071,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1879,6 +1898,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2353,6 +2375,10 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -3081,6 +3107,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -3177,6 +3206,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3351,6 +3383,13 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@anthropic-ai/sdk@0.115.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -3427,6 +3466,8 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -4238,6 +4279,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5217,6 +5260,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -5748,6 +5793,11 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -6827,6 +6877,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -6938,6 +6993,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:

--- a/scripts/generate-docs-corpus.mjs
+++ b/scripts/generate-docs-corpus.mjs
@@ -1,0 +1,59 @@
+// Builds the docs corpus used by the Ask AI assistant into a JSON module at
+// build time, so the chat API route has no runtime filesystem dependency
+// (required for hosts like Cloudflare Workers). Runs from postinstall and
+// the build script; output is gitignored.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DOCS_DIR = path.join(process.cwd(), 'content', 'docs');
+const OUT_FILE = path.join(process.cwd(), 'lib', 'docs-corpus.generated.json');
+
+function parseFrontmatter(raw) {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return { title: '', description: '', body: raw };
+  const frontmatter = match[1];
+  const get = (key) => {
+    const line = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+    return line ? line[1].trim().replace(/^['"]|['"]$/g, '') : '';
+  };
+  return {
+    title: get('title'),
+    description: get('description'),
+    body: raw.slice(match[0].length),
+  };
+}
+
+function collectPages(dir, segments = []) {
+  const pages = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      pages.push(...collectPages(path.join(dir, entry.name), [...segments, entry.name]));
+    } else if (entry.name.endsWith('.mdx')) {
+      const raw = fs.readFileSync(path.join(dir, entry.name), 'utf8');
+      const { title, description, body } = parseFrontmatter(raw);
+      const slug = entry.name.replace(/\.mdx$/, '');
+      const urlSegments = slug === 'index' ? segments : [...segments, slug];
+      pages.push({
+        url: `/docs${urlSegments.length > 0 ? `/${urlSegments.join('/')}` : ''}`,
+        title: title || slug,
+        description,
+        body,
+      });
+    }
+  }
+  return pages;
+}
+
+const pages = collectPages(DOCS_DIR);
+pages.sort((a, b) => a.url.localeCompare(b.url));
+const text = pages
+  .map(
+    (page) =>
+      `<page url="${page.url}" title="${page.title}"${
+        page.description ? ` description="${page.description}"` : ''
+      }>\n${page.body.trim()}\n</page>`,
+  )
+  .join('\n\n');
+
+fs.writeFileSync(OUT_FILE, JSON.stringify({ text }));
+console.log(`docs corpus: ${pages.length} pages, ${text.length} chars -> ${path.relative(process.cwd(), OUT_FILE)}`);


### PR DESCRIPTION
## Summary
Adds an "Ask AI" chat widget to the documentation site that allows users to ask questions about Codex Editor and receive answers grounded in the official documentation. The assistant uses Claude Haiku (or configurable LLM) with prompt caching for efficient, cost-effective responses.

## Key Changes

- **Chat UI Component** (`components/ask-ai.tsx`): Floating chat widget with message history, streaming responses, and markdown rendering. Includes suggested questions and graceful error handling.

- **Provider-Agnostic Chat Layer** (`lib/chat-provider.ts`): Abstraction supporting both Anthropic and OpenAI APIs. Model selection via `CHATBOT_MODEL` env var (defaults to `claude-haiku-4-5`); provider inferred from model name prefix.

- **Chat API Route** (`app/api/chat/route.ts`): Server endpoint that validates requests, applies per-IP rate limiting, and streams responses. Includes comprehensive instructions for the assistant to answer only from documentation.

- **Docs Corpus Generation** (`scripts/generate-docs-corpus.mjs`): Build-time script that extracts all MDX documentation pages, parses frontmatter, and generates a JSON module. Enables deployment on hosts without runtime filesystem access (e.g., Cloudflare Workers).

- **Docs Corpus Module** (`lib/docs-corpus.ts`): Exports the generated documentation corpus (~30k tokens) for use in chat prompts with Anthropic's prompt caching.

- **Integration**: Widget mounted in docs layout; build and postinstall scripts updated to generate corpus.

## Notable Implementation Details

- **Prompt Caching**: Anthropic requests use ephemeral cache control on the system prompt (docs corpus + instructions) to reduce costs on repeated questions.
- **Markdown Rendering**: Custom minimal renderer supporting links (internal and external), bold, inline code, bullet lists, and paragraphs—no external markdown library.
- **Rate Limiting**: Simple in-memory per-IP rate limiter (10 requests per 60 seconds) to prevent abuse.
- **Streaming**: Both Anthropic and OpenAI implementations stream responses as `ReadableStream<Uint8Array>` for real-time UI updates.
- **Error Handling**: Graceful fallbacks for API failures, aborted requests, and invalid inputs.

https://claude.ai/code/session_017JbXXvEHtp5Q2XdrUxtT3u